### PR TITLE
Base64 encoding and decoding

### DIFF
--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -4,203 +4,114 @@ pragma solidity ^0.8.24;
 import { IBase64 } from "../interfaces/precompile/IBase64.sol";
 
 library Base64 {
-    // solhint-disable private-vars-leading-underscore
     IBase64 internal constant BASE64 = IBase64(0x00000000000000000000000000000f043a000004);
-    // solhint-enable private-vars-leading-underscore
 
-    string internal constant TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    string internal constant TABLE_URL_SAFE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    string internal constant _TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    string internal constant _TABLE_URL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    /**
+     * @dev Internal encoding function supporting table lookup and optional padding.
+     */
+    function _encode(bytes memory data, string memory table, bool withPadding) private pure returns (string memory) {
+        if (data.length == 0) return "";
+
+        uint256 resultLength = withPadding ? 4 * ((data.length + 2) / 3) : (4 * data.length + 2) / 3;
+        string memory result = new string(resultLength);
+
+        assembly("memory-safe") {
+            let tablePtr := add(table, 1)
+            let resultPtr := add(result, 0x20)
+            let dataPtr := data
+            let endPtr := add(data, mload(data))
+            let afterPtr := add(endPtr, 0x20)
+            let afterCache := mload(afterPtr)
+            mstore(afterPtr, 0x00)
+
+            for { } lt(dataPtr, endPtr) { } {
+                dataPtr := add(dataPtr, 3)
+                let input := mload(dataPtr)
+
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(18, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(12, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(6, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(input, 0x3F))))
+                resultPtr := add(resultPtr, 1)
+            }
+
+            if withPadding {
+                switch mod(mload(data), 3)
+                case 1 {
+                    mstore8(sub(resultPtr, 1), 0x3d)
+                    mstore8(sub(resultPtr, 2), 0x3d)
+                }
+                case 2 {
+                    mstore8(sub(resultPtr, 1), 0x3d)
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Internal decoding function supporting table lookup.
+     */
+    function _decode(string memory encoded, string memory table) private pure returns (bytes memory) {
+        bytes memory input = bytes(encoded);
+        if (input.length == 0) return "";
+
+        uint256 decodedLen = input.length * 3 / 4;
+        bytes memory decoded = new bytes(decodedLen);
+
+        assembly ("memory-safe") {
+            let tablePtr := add(table, 1)
+            let inputPtr := add(input, 0x20)
+            let endPtr := add(inputPtr, mload(input))
+            let decodedPtr := add(decoded, 0x20)
+
+            for { } lt(inputPtr, endPtr) { } {
+                let sextetA := mload(add(tablePtr, byte(0, mload(inputPtr))))
+                inputPtr := add(inputPtr, 1)
+                let sextetB := mload(add(tablePtr, byte(0, mload(inputPtr))))
+                inputPtr := add(inputPtr, 1)
+                let sextetC := mload(add(tablePtr, byte(0, mload(inputPtr))))
+                inputPtr := add(inputPtr, 1)
+                let sextetD := mload(add(tablePtr, byte(0, mload(inputPtr))))
+                inputPtr := add(inputPtr, 1)
+
+                let triple := or(shl(18, sextetA), or(shl(12, sextetB), or(shl(6, sextetC), sextetD)))
+                
+                mstore8(decodedPtr, byte(2, triple))
+                decodedPtr := add(decodedPtr, 1)
+                mstore8(decodedPtr, byte(1, triple))
+                decodedPtr := add(decodedPtr, 1)
+                mstore8(decodedPtr, byte(0, triple))
+                decodedPtr := add(decodedPtr, 1)
+            }
+        }
+
+        return decoded;
+    }
 
     /// @dev Encodes the input data into a base64 string
     function encode(bytes memory _data) internal pure returns (string memory) {
-        // return BASE64.encode(_data);
-        if (_data.length == 0) return "";
-
-        // Load the table into memory
-        string memory table = TABLE;
-        uint256 encodedLen = 4 * ((_data.length + 2) / 3);
-
-        // Prepare the output string
-        string memory result = new string(encodedLen + 32);
-
-        
-        //This section uses inline assembly for efficient bitwise manipulation 
-        //and to directly access memory addresses, which saves gas.
-        assembly {
-            let tablePtr := add(table, 1)
-            let resultPtr := add(result, 32)
-
-            for { let i := 0 } lt(i, mload(_data)) { i := add(i, 3) } {
-                let input := and(mload(add(_data, i)), 0xffffff)
-
-                let out := mload(add(tablePtr, and(shr(18, input), 0x3F)))
-                out := shl(8, out)
-                out := add(out, mload(add(tablePtr, and(shr(12, input), 0x3F))))
-                out := shl(8, out)
-                out := add(out, mload(add(tablePtr, and(shr(6, input), 0x3F))))
-                out := shl(8, out)
-                out := add(out, mload(add(tablePtr, and(input, 0x3F))))
-                out := shl(224, out)
-
-                mstore(resultPtr, out)
-                resultPtr := add(resultPtr, 4)
-            }
-
-            switch mod(mload(_data), 3)
-            case 1 { mstore(sub(resultPtr, 2), shl(240, 0x3d3d)) }
-            case 2 { mstore(sub(resultPtr, 1), shl(248, 0x3d)) }
-
-            mstore(result, encodedLen)
-        }
-        return result;
-
+            return _encode(_data, _TABLE, true);
     }
 
     /// @dev Encodes the input data into a URL-safe base64 string
     function encodeURL(bytes memory _data) internal pure returns (string memory) {
-        // return BASE64.encodeURL(_data);
-
-        string memory base64 = encode(_data);
-        bytes memory base64Bytes = bytes(base64);
-
-        // Replace '+' and '/' with '-' and '_'
-        for (uint256 i = 0; i < base64Bytes.length; i++) {
-            if (base64Bytes[i] == "+") {
-                base64Bytes[i] = "-";
-            } else if (base64Bytes[i] == "/") {
-                base64Bytes[i] = "_";
-            }
-        }
-
-        return string(base64Bytes);
+        return _encode(_data, _TABLE_URL, false);
     }
 
     /// @dev Decodes the input base64 string into bytes
     function decode(string memory _data) internal pure returns (bytes memory) {
-        // return BASE64.decode(_data);
-        // Calculate the length of the decoded output
-        uint256 dataLen = bytes(_data).length;
-        require(dataLen % 4 == 0, "Invalid base64 input");
-        
-        uint256 decodedLen = (dataLen * 3) / 4;
-        bytes memory result = new bytes(decodedLen);
-
-        string memory table = TABLE;
-        
-        assembly {
-            let tablePtr := add(table, 1) // Pointer to the start of the table
-            let resultPtr := add(result, 0x20) // Point to the start of the result
-
-            for { let i := 0 } lt(i, dataLen) { i := add(i, 4) } {
-                // Read 4 bytes from the input
-                let input := mload(add(_data, i))
-
-                // Convert the Base64 characters to bytes
-                input := and(input, 0xffffffff) // Ensure input is 4 bytes
-                let out := add(
-                    add(
-                        add(
-                            shl(18, mload(add(tablePtr, and(shr(24, input), 0x3F)))),
-                            shl(12, mload(add(tablePtr, and(shr(18, input), 0x3F))))
-                        ),
-                        shl(6, mload(add(tablePtr, and(shr(12, input), 0x3F))))
-                    ),
-                    mload(add(tablePtr, and(shr(6, input), 0x3F)))
-                )
-
-                // Store the decoded bytes
-                mstore(resultPtr, and(out, 0xffffff)) // Store 3 bytes
-                resultPtr := add(resultPtr, 3)
-            }
-
-            // Handle padding
-            switch mod(dataLen, 4)
-            case 2 { mstore(sub(resultPtr, 1), 0) } // Remove the last byte for 2 padding characters
-            case 3 { mstore(sub(resultPtr, 2), 0) } // Remove the last two bytes for 1 padding character
-
-            mstore(result, decodedLen) // Store the actual length of the result
-        }
-
-        return result;
+        return _decode(_data, _TABLE);
     }
 
     /// @dev Decodes the input URL-safe base64 string into bytes
     function decodeURL(string memory _data) internal pure returns (bytes memory) {
-        // return BASE64.decodeURL(_data);
-        string memory base64String = _data;
-        base64String = replace(base64String, "-", "+");
-        base64String = replace(base64String, "_", "/");
-
-        // Handle padding
-        uint256 len = bytes(base64String).length;
-        if (len % 4 != 0) {
-            uint256 padding = 4 - (len % 4);
-            base64String = string(abi.encodePacked(base64String, new string(padding)));
-        }
-
-        return decode(base64String);
+        return _decode(_data, _TABLE_URL);
     }
-
-    // Helper function to replace characters in a string
-function replace(
-    string memory str,
-    string memory from,
-    string memory to
-) internal pure returns (string memory) {
-    bytes memory bStr = bytes(str);
-    bytes memory bSearch = bytes(from);
-    bytes memory bReplace = bytes(to);
-    
-    uint256 count = countOccurrences(bStr, bSearch);
-    bytes memory result = new bytes(bStr.length + (bReplace.length - bSearch.length) * count);
-    
-    copyWithReplacement(bStr, bSearch, bReplace, result);
-    
-    return string(result);
-}
-
-function countOccurrences(bytes memory bStr, bytes memory bSearch) 
-    internal 
-    pure 
-    returns (uint256 count) 
-    {
-        for (uint256 i = 0; i <= bStr.length - bSearch.length; i++) {
-            bool found = true;
-            for (uint256 j = 0; j < bSearch.length; j++) {
-                if (bStr[i + j] != bSearch[j]) {
-                    found = false;
-                    break;
-                }
-            }
-            if (found) count++;
-        }
-    }
-
-function copyWithReplacement(
-    bytes memory bStr,
-    bytes memory bSearch,
-    bytes memory bReplace,
-    bytes memory result) 
-    internal pure {
-        uint256 k;
-        for (uint256 i = 0; i < bStr.length; i++) {
-            bool found = true;
-            for (uint256 j = 0; j < bSearch.length; j++) {
-                if (bStr[i + j] != bSearch[j]) {
-                    found = false;
-                    break;
-                }
-            }
-            
-            if (found) {
-                for (uint256 j = 0; j < bReplace.length; j++) {
-                    result[k++] = bReplace[j];
-                }
-                i += bSearch.length - 1; // Skip the search length
-            } else {
-                result[k++] = bStr[i];
-            }
-        }
-    }
-
 }

--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -8,23 +8,199 @@ library Base64 {
     IBase64 internal constant BASE64 = IBase64(0x00000000000000000000000000000f043a000004);
     // solhint-enable private-vars-leading-underscore
 
+    string internal constant TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    string internal constant TABLE_URL_SAFE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
     /// @dev Encodes the input data into a base64 string
     function encode(bytes memory _data) internal pure returns (string memory) {
-        return BASE64.encode(_data);
+        // return BASE64.encode(_data);
+        if (_data.length == 0) return "";
+
+        // Load the table into memory
+        string memory table = TABLE;
+        uint256 encodedLen = 4 * ((_data.length + 2) / 3);
+
+        // Prepare the output string
+        string memory result = new string(encodedLen + 32);
+
+        
+        //This section uses inline assembly for efficient bitwise manipulation 
+        //and to directly access memory addresses, which saves gas.
+        assembly {
+            let tablePtr := add(table, 1)
+            let resultPtr := add(result, 32)
+
+            for { let i := 0 } lt(i, mload(_data)) { i := add(i, 3) } {
+                let input := and(mload(add(_data, i)), 0xffffff)
+
+                let out := mload(add(tablePtr, and(shr(18, input), 0x3F)))
+                out := shl(8, out)
+                out := add(out, mload(add(tablePtr, and(shr(12, input), 0x3F))))
+                out := shl(8, out)
+                out := add(out, mload(add(tablePtr, and(shr(6, input), 0x3F))))
+                out := shl(8, out)
+                out := add(out, mload(add(tablePtr, and(input, 0x3F))))
+                out := shl(224, out)
+
+                mstore(resultPtr, out)
+                resultPtr := add(resultPtr, 4)
+            }
+
+            switch mod(mload(_data), 3)
+            case 1 { mstore(sub(resultPtr, 2), shl(240, 0x3d3d)) }
+            case 2 { mstore(sub(resultPtr, 1), shl(248, 0x3d)) }
+
+            mstore(result, encodedLen)
+        }
+        return result;
+
     }
 
     /// @dev Encodes the input data into a URL-safe base64 string
     function encodeURL(bytes memory _data) internal pure returns (string memory) {
-        return BASE64.encodeURL(_data);
+        // return BASE64.encodeURL(_data);
+
+        string memory base64 = encode(_data);
+        bytes memory base64Bytes = bytes(base64);
+
+        // Replace '+' and '/' with '-' and '_'
+        for (uint256 i = 0; i < base64Bytes.length; i++) {
+            if (base64Bytes[i] == "+") {
+                base64Bytes[i] = "-";
+            } else if (base64Bytes[i] == "/") {
+                base64Bytes[i] = "_";
+            }
+        }
+
+        return string(base64Bytes);
     }
 
     /// @dev Decodes the input base64 string into bytes
     function decode(string memory _data) internal pure returns (bytes memory) {
-        return BASE64.decode(_data);
+        // return BASE64.decode(_data);
+        // Calculate the length of the decoded output
+        uint256 dataLen = bytes(_data).length;
+        require(dataLen % 4 == 0, "Invalid base64 input");
+        
+        uint256 decodedLen = (dataLen * 3) / 4;
+        bytes memory result = new bytes(decodedLen);
+
+        string memory table = TABLE;
+        
+        assembly {
+            let tablePtr := add(table, 1) // Pointer to the start of the table
+            let resultPtr := add(result, 0x20) // Point to the start of the result
+
+            for { let i := 0 } lt(i, dataLen) { i := add(i, 4) } {
+                // Read 4 bytes from the input
+                let input := mload(add(_data, i))
+
+                // Convert the Base64 characters to bytes
+                input := and(input, 0xffffffff) // Ensure input is 4 bytes
+                let out := add(
+                    add(
+                        add(
+                            shl(18, mload(add(tablePtr, and(shr(24, input), 0x3F)))),
+                            shl(12, mload(add(tablePtr, and(shr(18, input), 0x3F))))
+                        ),
+                        shl(6, mload(add(tablePtr, and(shr(12, input), 0x3F))))
+                    ),
+                    mload(add(tablePtr, and(shr(6, input), 0x3F)))
+                )
+
+                // Store the decoded bytes
+                mstore(resultPtr, and(out, 0xffffff)) // Store 3 bytes
+                resultPtr := add(resultPtr, 3)
+            }
+
+            // Handle padding
+            switch mod(dataLen, 4)
+            case 2 { mstore(sub(resultPtr, 1), 0) } // Remove the last byte for 2 padding characters
+            case 3 { mstore(sub(resultPtr, 2), 0) } // Remove the last two bytes for 1 padding character
+
+            mstore(result, decodedLen) // Store the actual length of the result
+        }
+
+        return result;
     }
 
     /// @dev Decodes the input URL-safe base64 string into bytes
     function decodeURL(string memory _data) internal pure returns (bytes memory) {
-        return BASE64.decodeURL(_data);
+        // return BASE64.decodeURL(_data);
+        string memory base64String = _data;
+        base64String = replace(base64String, "-", "+");
+        base64String = replace(base64String, "_", "/");
+
+        // Handle padding
+        uint256 len = bytes(base64String).length;
+        if (len % 4 != 0) {
+            uint256 padding = 4 - (len % 4);
+            base64String = string(abi.encodePacked(base64String, new string(padding)));
+        }
+
+        return decode(base64String);
     }
+
+    // Helper function to replace characters in a string
+function replace(
+    string memory str,
+    string memory from,
+    string memory to
+) internal pure returns (string memory) {
+    bytes memory bStr = bytes(str);
+    bytes memory bSearch = bytes(from);
+    bytes memory bReplace = bytes(to);
+    
+    uint256 count = countOccurrences(bStr, bSearch);
+    bytes memory result = new bytes(bStr.length + (bReplace.length - bSearch.length) * count);
+    
+    copyWithReplacement(bStr, bSearch, bReplace, result);
+    
+    return string(result);
+}
+
+function countOccurrences(bytes memory bStr, bytes memory bSearch) 
+    internal 
+    pure 
+    returns (uint256 count) 
+    {
+        for (uint256 i = 0; i <= bStr.length - bSearch.length; i++) {
+            bool found = true;
+            for (uint256 j = 0; j < bSearch.length; j++) {
+                if (bStr[i + j] != bSearch[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) count++;
+        }
+    }
+
+function copyWithReplacement(
+    bytes memory bStr,
+    bytes memory bSearch,
+    bytes memory bReplace,
+    bytes memory result) 
+    internal pure {
+        uint256 k;
+        for (uint256 i = 0; i < bStr.length; i++) {
+            bool found = true;
+            for (uint256 j = 0; j < bSearch.length; j++) {
+                if (bStr[i + j] != bSearch[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            
+            if (found) {
+                for (uint256 j = 0; j < bReplace.length; j++) {
+                    result[k++] = bReplace[j];
+                }
+                i += bSearch.length - 1; // Skip the search length
+            } else {
+                result[k++] = bStr[i];
+            }
+        }
+    }
+
 }

--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -9,92 +9,6 @@ library Base64 {
     string internal constant _TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     string internal constant _TABLE_URL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
-    /**
-     * @dev Internal encoding function supporting table lookup and optional padding.
-     */
-    function _encode(bytes memory data, string memory table, bool withPadding) private pure returns (string memory) {
-        if (data.length == 0) return "";
-
-        uint256 resultLength = withPadding ? 4 * ((data.length + 2) / 3) : (4 * data.length + 2) / 3;
-        string memory result = new string(resultLength);
-
-        assembly("memory-safe") {
-            let tablePtr := add(table, 1)
-            let resultPtr := add(result, 0x20)
-            let dataPtr := data
-            let endPtr := add(data, mload(data))
-            let afterPtr := add(endPtr, 0x20)
-            let afterCache := mload(afterPtr)
-            mstore(afterPtr, 0x00)
-
-            for { } lt(dataPtr, endPtr) { } {
-                dataPtr := add(dataPtr, 3)
-                let input := mload(dataPtr)
-
-                mstore8(resultPtr, mload(add(tablePtr, and(shr(18, input), 0x3F))))
-                resultPtr := add(resultPtr, 1)
-                mstore8(resultPtr, mload(add(tablePtr, and(shr(12, input), 0x3F))))
-                resultPtr := add(resultPtr, 1)
-                mstore8(resultPtr, mload(add(tablePtr, and(shr(6, input), 0x3F))))
-                resultPtr := add(resultPtr, 1)
-                mstore8(resultPtr, mload(add(tablePtr, and(input, 0x3F))))
-                resultPtr := add(resultPtr, 1)
-            }
-
-            if withPadding {
-                switch mod(mload(data), 3)
-                case 1 {
-                    mstore8(sub(resultPtr, 1), 0x3d)
-                    mstore8(sub(resultPtr, 2), 0x3d)
-                }
-                case 2 {
-                    mstore8(sub(resultPtr, 1), 0x3d)
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
-     * @dev Internal decoding function supporting table lookup.
-     */
-    function _decode(string memory encoded, string memory table) private pure returns (bytes memory) {
-        bytes memory input = bytes(encoded);
-        if (input.length == 0) return "";
-
-        uint256 decodedLen = input.length * 3 / 4;
-        bytes memory decoded = new bytes(decodedLen);
-
-        assembly ("memory-safe") {
-            let tablePtr := add(table, 1)
-            let inputPtr := add(input, 0x20)
-            let endPtr := add(inputPtr, mload(input))
-            let decodedPtr := add(decoded, 0x20)
-
-            for { } lt(inputPtr, endPtr) { } {
-                let sextetA := mload(add(tablePtr, byte(0, mload(inputPtr))))
-                inputPtr := add(inputPtr, 1)
-                let sextetB := mload(add(tablePtr, byte(0, mload(inputPtr))))
-                inputPtr := add(inputPtr, 1)
-                let sextetC := mload(add(tablePtr, byte(0, mload(inputPtr))))
-                inputPtr := add(inputPtr, 1)
-                let sextetD := mload(add(tablePtr, byte(0, mload(inputPtr))))
-                inputPtr := add(inputPtr, 1)
-
-                let triple := or(shl(18, sextetA), or(shl(12, sextetB), or(shl(6, sextetC), sextetD)))
-                
-                mstore8(decodedPtr, byte(2, triple))
-                decodedPtr := add(decodedPtr, 1)
-                mstore8(decodedPtr, byte(1, triple))
-                decodedPtr := add(decodedPtr, 1)
-                mstore8(decodedPtr, byte(0, triple))
-                decodedPtr := add(decodedPtr, 1)
-            }
-        }
-
-        return decoded;
-    }
-
     /// @dev Encodes the input data into a base64 string
     function encode(bytes memory _data) internal pure returns (string memory) {
             return _encode(_data, _TABLE, true);
@@ -114,4 +28,110 @@ library Base64 {
     function decodeURL(string memory _data) internal pure returns (bytes memory) {
         return _decode(_data, _TABLE_URL);
     }
+
+    /**
+     * @dev Internal encoding function supporting table lookup and optional padding.
+     * This function encodes a given `data` (in `bytes` format) into a string using a custom base64-like encoding table.
+     * Padding is optional based on the `withPadding` argument.
+     * 
+     * @param data The data to be encoded in bytes format.
+     * @param table The table to be used for encoding (typically a string of characters representing the base64 alphabet).
+     * @param withPadding A boolean indicating whether padding should be added to the result.
+     * @return result The encoded string.
+     */
+    function _encode(bytes memory data, string memory table, bool withPadding) private pure returns (string memory) {
+        if (data.length == 0) return "";
+
+        // Calculate the length of the encoded result
+        uint256 resultLength = withPadding ? 4 * ((data.length + 2) / 3) : (4 * data.length + 2) / 3;
+
+        // Allocate memory for the result string
+        string memory result = new string(resultLength);
+
+        assembly("memory-safe") {
+            let tablePtr := add(table, 1)  // Skip the first byte of the string to get the actual characters
+            let resultPtr := add(result, 0x20)  // Result starts after the 32-byte length prefix
+            let dataPtr := data
+            let endPtr := add(data, mload(data))  // End of the input data
+
+            // Iterate over the input data in chunks of 3 bytes
+            for { } lt(dataPtr, endPtr) { } {
+                // Load the next 3-byte chunk of data
+                dataPtr := add(dataPtr, 3)
+                let input := mload(dataPtr)
+
+                // Map the 3 bytes into 4 encoded characters using the lookup table
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(18, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(12, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(shr(6, input), 0x3F))))
+                resultPtr := add(resultPtr, 1)
+                mstore8(resultPtr, mload(add(tablePtr, and(input, 0x3F))))
+                resultPtr := add(resultPtr, 1)
+            }
+
+            // Handle padding if required
+            if withPadding {
+                switch mod(mload(data), 3)
+                case 1 {
+                    // If padding is needed, add two '=' characters
+                    mstore8(sub(resultPtr, 1), 0x3d)
+                    mstore8(sub(resultPtr, 2), 0x3d)
+                }
+                case 2 {
+                    // If only one padding is needed, add one '=' character
+                    mstore8(sub(resultPtr, 1), 0x3d)
+                }
+            }
+        }
+        
+        return result;
+    }
+
+    /**
+     * @dev Internal decoding function supporting table lookup.
+     * This function decodes an encoded string back into bytes using a custom base64-like decoding table.
+     * 
+     * @param data The encoded string to be decoded.
+     * @param table The table to be used for decoding (typically a string of characters representing the base64 alphabet).
+     * @return result The decoded data as bytes.
+     */
+    function _decode(string memory data, string memory table) private pure returns (bytes memory) {
+        uint256 len = bytes(data).length;  // Get the length of the input encoded data
+        if (len == 0) return "";  // If the input is empty, return an empty bytes array
+
+        // Initialize the decoding lookup table (map characters to their indices)
+        uint8[128] memory decodeTable;
+        for (uint8 i = 0; i < bytes(table).length; i++) {
+            decodeTable[uint8(bytes(table)[i])] = i;
+        }
+
+        // Calculate padding and the actual decoded output length
+        uint256 padding = 0;
+        if (bytes(data)[len - 1] == '=') padding++;  // Check for padding at the end
+        if (len > 1 && bytes(data)[len - 2] == '=') padding++;  // Check for second padding character if present
+        uint256 decodedLen = (len * 3) / 4 - padding;  // Calculate the length of the decoded data
+
+        // Allocate memory for the decoded result
+        bytes memory result = new bytes(decodedLen);
+        uint256 resultIndex = 0;
+
+        // Iterate over the input string in chunks of 4 characters
+        for (uint256 i = 0; i < len; i += 4) {
+            // Combine the 4 encoded characters into a 24-bit buffer
+            uint32 buffer = (uint32(decodeTable[uint8(bytes(data)[i])]) << 18)
+                        | (uint32(decodeTable[uint8(bytes(data)[i + 1])]) << 12)
+                        | (uint32(decodeTable[uint8(bytes(data)[i + 2])]) << 6)
+                        | uint32(decodeTable[uint8(bytes(data)[i + 3])]);
+
+            // Extract the decoded bytes from the buffer
+            result[resultIndex++] = bytes1(uint8(buffer >> 16));
+            if (resultIndex < decodedLen) result[resultIndex++] = bytes1(uint8(buffer >> 8));
+            if (resultIndex < decodedLen) result[resultIndex++] = bytes1(uint8(buffer));
+        }
+
+        return result;
+    }
+
 }

--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -9,6 +9,9 @@ library Base64 {
     string internal constant _TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     string internal constant _TABLE_URL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
+    uint256 private constant MAX_INPUT_LENGTH = 1_000_000; // 1MB
+    uint256 private constant MAX_ENCODED_LENGTH = 1_333_334;
+
     /// @dev Encodes the input data into a base64 string
     function encode(bytes memory _data) internal pure returns (string memory) {
             return _encode(_data, _TABLE, true);
@@ -41,6 +44,7 @@ library Base64 {
      */
     function _encode(bytes memory data, string memory table, bool withPadding) private pure returns (string memory) {
         if (data.length == 0) return "";
+        require(data.length <= MAX_INPUT_LENGTH, "Base64: input too long");
 
         // Calculate the length of the encoded result
         uint256 resultLength = withPadding ? 4 * ((data.length + 2) / 3) : (4 * data.length + 2) / 3;
@@ -100,6 +104,8 @@ library Base64 {
     function _decode(string memory data, string memory table) private pure returns (bytes memory) {
         uint256 len = bytes(data).length;  // Get the length of the input encoded data
         if (len == 0) return "";  // If the input is empty, return an empty bytes array
+        require(len <= MAX_ENCODED_LENGTH, "Base64: encoded input too long");
+        require(len % 4 == 0, "Base64: invalid input length"); // Ensure input is properly padded
 
         // Initialize the decoding lookup table (map characters to their indices)
         uint8[128] memory decodeTable;

--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -16,7 +16,7 @@ library Base64 {
 
     /// @dev Encodes the input data into a URL-safe base64 string
     function encodeURL(bytes memory _data) internal pure returns (string memory) {
-        return _encode(_data, _TABLE_URL, false);
+        return _encode(_data, _TABLE_URL, true);
     }
 
     /// @dev Decodes the input base64 string into bytes

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.0",
-    "@openzeppelin/contracts-upgradeable": "^5.0.0"
+    "@openzeppelin/contracts-upgradeable": "^5.0.0",
+    "chai": "^5.1.2"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.3",
@@ -44,7 +45,7 @@
     "build": "forge build --extra-output-files bin --extra-output-files abi",
     "build:ts": "yarn hardhat-esm compile && tsc",
     "build:docs": "yarn hardhat docgen",
-    "hardhat-esm": "NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only --no-warnings=ExperimentalWarning' hardhat --config hardhat.config.cts",
+    "hardhat-esm": "NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only --no-warnings=ExperimentalWarning' hardhat --config hardhat.config.ts",
     "thirdweb:build": "bun thirdweb@latest detect",
     "thirdweb:deploy": "bun thirdweb@latest deploy",
     "thirdweb:release": "bun thirdweb@latest release"

--- a/test/TestBase64.t.sol
+++ b/test/TestBase64.t.sol
@@ -8,7 +8,6 @@ contract Base64Test is Test {
     using Base64 for bytes;
 
     function testEncode() public {
-        // Test case for encode
         bytes memory data = bytes("hello world");
         string memory encoded = Base64.encode(data);
         string memory expected = "aGVsbG8gd29ybGQ="; // "hello world" in Base64
@@ -16,47 +15,32 @@ contract Base64Test is Test {
     }
 
     function testEncodeURL() public {
-        // Test case for encodeURL
         bytes memory data = bytes("hello world");
         string memory encodedURL = Base64.encodeURL(data);
-        string memory expected = "aGVsbG8gd29ybGQ"; // "hello world" in Base64URL without padding
+        string memory expected = "aGVsbG8gd29ybGQ";
         assertEq(encodedURL, expected, "Base64URL encode failed");
     }
 
-    // function testDecode() public {
-    //     // Test case for decode
-    //     string memory encoded = "aGVsbG8gd29ybGQ="; // "hello world" in Base64
-    //     bytes memory decoded = Base64.decode(encoded);
-    //     bytes memory expected = bytes("hello world");
-    //     assertEq(decoded, expected, "Base64 decode failed");
-    // }
+    function testDecode() public {
+        bytes memory decoded = Base64.decode("SGVsbG8=");
+        assertEq(string(decoded), "Hello");
+    }
 
-    // function testDecodeURL() public {
-    //     // Test case for decodeURL
-    //     string memory encodedURL = "aGVsbG8gd29ybGQ"; // "hello world" in Base64URL without padding
-    //     bytes memory decodedURL = Base64.decodeURL(encodedURL);
-    //     bytes memory expected = bytes("hello world");
-    //     assertEq(decodedURL, expected, "Base64URL decode failed");
-    // }
+    function testEncodeDecode() public {
+        bytes memory data = bytes("Test encoding and decoding round-trip!");
+        string memory encoded = Base64.encode(data);
+        bytes memory decoded = Base64.decode(encoded);
+        assertEq(decoded, data, "Round-trip Base64 encode/decode failed");
+    }
 
-    // function testEncodeDecode() public {
-    //     // Test round-trip encoding and decoding
-    //     bytes memory data = bytes("Test encoding and decoding round-trip!");
-    //     string memory encoded = Base64.encode(data);
-    //     bytes memory decoded = Base64.decode(encoded);
-    //     assertEq(decoded, data, "Round-trip Base64 encode/decode failed");
-    // }
-
-    // function testEncodeDecodeURL() public {
-    //     // Test round-trip encoding and decoding for URL
-    //     bytes memory data = bytes("Test encoding and decoding round-trip URL!");
-    //     string memory encodedURL = Base64.encodeURL(data);
-    //     bytes memory decodedURL = Base64.decodeURL(encodedURL);
-    //     assertEq(decodedURL, data, "Round-trip Base64URL encode/decode failed");
-    // }
+    function testEncodeDecodeURL() public {
+        bytes memory data = bytes("Test encoding and decoding round-trip URL!");
+        string memory encodedURL = Base64.encodeURL(data);
+        bytes memory decodedURL = Base64.decodeURL(encodedURL);
+        assertEq(decodedURL, data, "Round-trip Base64URL encode/decode failed");
+    }
 
     function testEmptyEncodeDecode() public {
-        // Test edge case for empty input
         bytes memory data = bytes("");
         string memory encoded = Base64.encode(data);
         bytes memory decoded = Base64.decode(encoded);
@@ -64,7 +48,6 @@ contract Base64Test is Test {
     }
 
     function testEmptyEncodeDecodeURL() public {
-        // Test edge case for empty input in Base64URL
         bytes memory data = bytes("");
         string memory encodedURL = Base64.encodeURL(data);
         bytes memory decodedURL = Base64.decodeURL(encodedURL);

--- a/test/TestBase64.t.sol
+++ b/test/TestBase64.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../contracts/utils/Base64.sol" ;
+
+contract Base64Test is Test {
+    using Base64 for bytes;
+
+    function testEncode() public {
+        // Test case for encode
+        bytes memory data = bytes("hello world");
+        string memory encoded = Base64.encode(data);
+        string memory expected = "aGVsbG8gd29ybGQ="; // "hello world" in Base64
+        assertEq(encoded, expected, "Base64 encode failed");
+    }
+
+    function testEncodeURL() public {
+        // Test case for encodeURL
+        bytes memory data = bytes("hello world");
+        string memory encodedURL = Base64.encodeURL(data);
+        string memory expected = "aGVsbG8gd29ybGQ"; // "hello world" in Base64URL without padding
+        assertEq(encodedURL, expected, "Base64URL encode failed");
+    }
+
+    // function testDecode() public {
+    //     // Test case for decode
+    //     string memory encoded = "aGVsbG8gd29ybGQ="; // "hello world" in Base64
+    //     bytes memory decoded = Base64.decode(encoded);
+    //     bytes memory expected = bytes("hello world");
+    //     assertEq(decoded, expected, "Base64 decode failed");
+    // }
+
+    // function testDecodeURL() public {
+    //     // Test case for decodeURL
+    //     string memory encodedURL = "aGVsbG8gd29ybGQ"; // "hello world" in Base64URL without padding
+    //     bytes memory decodedURL = Base64.decodeURL(encodedURL);
+    //     bytes memory expected = bytes("hello world");
+    //     assertEq(decodedURL, expected, "Base64URL decode failed");
+    // }
+
+    // function testEncodeDecode() public {
+    //     // Test round-trip encoding and decoding
+    //     bytes memory data = bytes("Test encoding and decoding round-trip!");
+    //     string memory encoded = Base64.encode(data);
+    //     bytes memory decoded = Base64.decode(encoded);
+    //     assertEq(decoded, data, "Round-trip Base64 encode/decode failed");
+    // }
+
+    // function testEncodeDecodeURL() public {
+    //     // Test round-trip encoding and decoding for URL
+    //     bytes memory data = bytes("Test encoding and decoding round-trip URL!");
+    //     string memory encodedURL = Base64.encodeURL(data);
+    //     bytes memory decodedURL = Base64.decodeURL(encodedURL);
+    //     assertEq(decodedURL, data, "Round-trip Base64URL encode/decode failed");
+    // }
+
+    function testEmptyEncodeDecode() public {
+        // Test edge case for empty input
+        bytes memory data = bytes("");
+        string memory encoded = Base64.encode(data);
+        bytes memory decoded = Base64.decode(encoded);
+        assertEq(decoded, data, "Empty Base64 encode/decode failed");
+    }
+
+    function testEmptyEncodeDecodeURL() public {
+        // Test edge case for empty input in Base64URL
+        bytes memory data = bytes("");
+        string memory encodedURL = Base64.encodeURL(data);
+        bytes memory decodedURL = Base64.decodeURL(encodedURL);
+        assertEq(decodedURL, data, "Empty Base64URL encode/decode failed");
+    }
+}

--- a/test/utils/TestBase64.t.sol
+++ b/test/utils/TestBase64.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
-import "../contracts/utils/Base64.sol" ;
+import "../../contracts/utils/Base64.sol" ;
 
 contract Base64Test is Test {
     using Base64 for bytes;
@@ -15,10 +15,18 @@ contract Base64Test is Test {
     }
 
     function testEncodeURL() public {
-        bytes memory data = bytes("hello world");
+        bytes memory data = bytes("http://pepe.com:8545");
         string memory encodedURL = Base64.encodeURL(data);
-        string memory expected = "aGVsbG8gd29ybGQ";
+        string memory expected = "aHR0cDovL3BlcGUuY29tOjg1NDU=";
         assertEq(encodedURL, expected, "Base64URL encode failed");
+    }
+
+    function testDecodePath() public{
+        bytes memory filePath = bytes("file://pepe.json");
+        string memory encodedfilePath = Base64.encodeURL(filePath);
+        string memory expectedfilePath = "ZmlsZTovL3BlcGUuanNvbg==";
+
+        assertEq(encodedfilePath, expectedfilePath, "Base64URL encode for path failed");
     }
 
     function testDecode() public {
@@ -34,7 +42,7 @@ contract Base64Test is Test {
     }
 
     function testEncodeDecodeURL() public {
-        bytes memory data = bytes("Test encoding and decoding round-trip URL!");
+        bytes memory data = bytes("http://pepe.com:8545");
         string memory encodedURL = Base64.encodeURL(data);
         bytes memory decodedURL = Base64.decodeURL(encodedURL);
         assertEq(decodedURL, data, "Round-trip Base64URL encode/decode failed");

--- a/test/utils/TestBase64.t.sol
+++ b/test/utils/TestBase64.t.sol
@@ -61,4 +61,40 @@ contract Base64Test is Test {
         bytes memory decodedURL = Base64.decodeURL(encodedURL);
         assertEq(decodedURL, data, "Empty Base64URL encode/decode failed");
     }
+
+    function testEncodeMaxLength() public {
+        bytes memory tooLongInput = new bytes(1_000_001);  // MAX_INPUT_LENGTH + 1
+        
+        // Fill with some data
+        for(uint i = 0; i < tooLongInput.length; i++) {
+            tooLongInput[i] = 0x41; // ASCII 'A'
+        }
+        
+        vm.expectRevert("Base64: input too long");
+        Base64.encode(tooLongInput);
+        
+        vm.expectRevert("Base64: input too long");
+        Base64.encodeURL(tooLongInput);
+        
+        // Test with exactly max length (should pass)
+        bytes memory maxLengthInput = new bytes(1_000_000);  // MAX_INPUT_LENGTH
+        for(uint i = 0; i < maxLengthInput.length; i++) {
+            maxLengthInput[i] = 0x41;
+        }
+        
+        // These should not revert
+        Base64.encode(maxLengthInput);
+        Base64.encodeURL(maxLengthInput);
+    }
+
+    function testInvalidDecodeLength() public {
+        // Create input with length not multiple of 4
+        string memory invalidLength = "SGVsbG8=W"; // 9 characters
+        
+        vm.expectRevert("Base64: invalid input length");
+        Base64.decode(invalidLength);
+        
+        vm.expectRevert("Base64: invalid input length");
+        Base64.decodeURL(invalidLength);
+    }
 }


### PR DESCRIPTION
This PR adds a library for base64 encoding and decoding with custom table support for safe url parsing.
Added two internal functions.
- **_encode**: Encodes `bytes` data into a base64-like string using a custom encoding table, with optional padding.
- **_decode**: Decodes a base64-like string back to `bytes` using a custom decoding table, handling padding.

to test
```
forge test
```