### PR TITLE
feat: Four level random Prizes

### DIFF
--- a/contracts/apps/nft.sol
+++ b/contracts/apps/nft.sol
@@ -4,42 +4,50 @@ pragma solidity ^0.8.24;
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { ERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import { ERC721Consecutive } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Consecutive.sol";
 import { Integers } from "../utils/Integers.sol";
 
-contract LazyNFT is ERC721, ERC721Enumerable, Ownable {
-    uint16 private constant _TOKEN_CAP = 4;
+contract LazyNFT is ERC721, ERC721Enumerable, Ownable, ERC721Consecutive {
+    uint16 private _tokenCap;
     uint256 private _nextTokenId = 0;
 
-    error TokenCapExceeded();
+    error LazyNFTTokenCapExceeded();
 
     constructor(
         address initialOwner,
         string memory _name,
-        string memory _symbol
-    ) ERC721(_name, _symbol) Ownable(initialOwner) {}
+        string memory _symbol,
+        uint16 tokenCap
+    ) ERC721(_name, _symbol) Ownable(initialOwner) {
+        _tokenCap = tokenCap;
+    }
 
     function _baseURI() internal pure override returns (string memory) {
         return "ipfs://lazyhash/";
+    }
+
+    function _ownerOf(uint256 tokenId) internal view virtual override(ERC721, ERC721Consecutive) returns (address) {
+        return super._ownerOf(tokenId); // ERC721
     }
 
     function _update(
         address to,
         uint256 tokenId,
         address auth
-    ) internal virtual override(ERC721, ERC721Enumerable) returns (address) {
-        return super._update(to, tokenId, auth);
+    ) internal virtual override(ERC721, ERC721Enumerable, ERC721Consecutive) returns (address) {
+        return super._update(to, tokenId, auth); // ERC721
     }
 
     function _increaseBalance(address account, uint128 amount) internal override(ERC721, ERC721Enumerable) {
-        super._increaseBalance(account, amount);
+        super._increaseBalance(account, amount); // ERC721
     }
 
     function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721Enumerable) returns (bool) {
-        return super.supportsInterface(interfaceId);
+        return super.supportsInterface(interfaceId); // ERC721
     }
 
     function safeMint(address to) public onlyOwner {
-        if (_nextTokenId >= _TOKEN_CAP) revert TokenCapExceeded();
+        if (_nextTokenId >= _tokenCap) revert LazyNFTTokenCapExceeded();
         uint256 tokenId = _nextTokenId++;
         _safeMint(to, tokenId);
     }


### PR DESCRIPTION
We want when a user draw, to have 4 different probabilities of getting 4 `types` of NFTs.
This is a basic algorithm by `ranges` to try to give priority and selection over a unique random number per height .
The `draw` return now have to send the nft Token `id` as result instead of a simple true ( since now the user once it win, it can have 4 types of nfts as result of the mint)