### PR TITLE
Fixes tests for Integers and Strings

### DIFF
--- a/contracts/utils/Integers.sol
+++ b/contracts/utils/Integers.sol
@@ -91,7 +91,10 @@ library Integers {
     function fromHexString(string memory _str) internal pure returns (uint256) {
         bytes memory strBytes = bytes(_str);
         uint256 strBytesLength = strBytes.length;
-        if (strBytesLength >= 3 && strBytes[0] == "0" && (strBytes[1] == "x" || strBytes[1] == "X"))
+        if (strBytesLength < 3) revert InvalidHexString();
+
+        // Check for 0x prefix
+        if (strBytes[0] != "0" || (strBytes[1] != "x" && strBytes[1] != "X")) 
             revert InvalidHexString();
 
         uint256 result = 0;

--- a/contracts/utils/Strings.sol
+++ b/contracts/utils/Strings.sol
@@ -173,10 +173,10 @@ library Strings {
         uint256 k = 0;
         uint256 length = padCount * padBytes.length;
         for (uint256 i = 0; i < length; ++i) {
-            result[++k] = padBytes[i % padBytes.length];
+            result[k++] = padBytes[i % padBytes.length];
         }
         for (uint256 i = 0; i < strLen; ++i) {
-            result[++k] = strBytes[i];
+            result[k++] = strBytes[i];
         }
         return string(result);
     }
@@ -195,12 +195,12 @@ library Strings {
 
         uint256 k = 0;
         for (uint256 i = 0; i < strLen; ++i) {
-            result[++k] = strBytes[i];
+            result[k++] = strBytes[i];
         }
         uint256 padBytesLength = padBytes.length;
         uint256 length = padCount * padBytesLength;
         for (uint256 i = 0; i < length; ++i) {
-            result[++k] = padBytes[i % padBytesLength];
+            result[k++] = padBytes[i % padBytesLength];
         }
         return string(result);
     }
@@ -343,9 +343,9 @@ library Strings {
         bytes memory combined = new bytes(aLength + bLength + cLength);
         uint256 k = 0;
 
-        for (uint256 i = 0; i < aLength; ++i) combined[++k] = a[i];
-        for (uint256 i = 0; i < bLength; ++i) combined[++k] = b[i];
-        for (uint256 i = 0; i < cLength; ++i) combined[++k] = c[i];
+        for (uint256 i = 0; i < aLength; ++i) combined[k++] = a[i];
+        for (uint256 i = 0; i < bLength; ++i) combined[k++] = b[i];
+        for (uint256 i = 0; i < cLength; ++i) combined[k++] = c[i];
 
         return combined;
     }
@@ -369,7 +369,7 @@ library Strings {
             uint256 delimIndex = findSubstring(str, delim, position);
             if (delimIndex == str.length) break;
 
-            tempPositions[++posCount] = delimIndex;
+            tempPositions[posCount++] = delimIndex;
             position = delimIndex + delim.length;
         }
 

--- a/test/utils/TestIntegers.t.sol
+++ b/test/utils/TestIntegers.t.sol
@@ -8,6 +8,9 @@ contract IntegersTest is Test {
     using Integers for uint256;
     using Integers for int256;
 
+    error InvalidHexString();
+    error InvalidHexCharacter();
+
     function testToStringUint256() public {
         assertEq(uint256(0).toString(), "0");
         assertEq(uint256(12345).toString(), "12345");
@@ -39,7 +42,7 @@ contract IntegersTest is Test {
     }
 
     function testInvalidHexString() public {
-        vm.expectRevert("Invalid hex string");
+        vm.expectRevert(InvalidHexString.selector);
         Integers.fromHexString("0x");
     }
 }


### PR DESCRIPTION
results:
```solidity
Ran 6 tests for test/utils/TestIntegers.t.sol:IntegersTest
[PASS] testFromHexString() (gas: 10996)
[PASS] testInvalidHexString() (gas: 3391)
[PASS] testToHexStringUint256() (gas: 9772)
[PASS] testToHexStringWithLength() (gas: 8179)
[PASS] testToStringInt256() (gas: 12699)
[PASS] testToStringUint256() (gas: 12597)
Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 373.63µs (443.79µs CPU time)
```
```solidity
Ran 15 tests for test/utils/TestStrings.t.sol:StringsTest
[PASS] testContains() (gas: 13734)
[PASS] testEndsWith() (gas: 7488)
[PASS] testEqual() (gas: 7047)
[PASS] testEqualCaseFold() (gas: 21902)
[PASS] testIndexOf() (gas: 11565)
[PASS] testPadEnd() (gas: 8199)
[PASS] testPadStart() (gas: 8221)
[PASS] testRepeat() (gas: 10820)
[PASS] testReplace() (gas: 23489)
[PASS] testReplaceAll() (gas: 33019)
[PASS] testSplit() (gas: 22359)
[PASS] testStartsWith() (gas: 6841)
[PASS] testToLowerCase() (gas: 7708)
[PASS] testToUpperCase() (gas: 7433)
[PASS] testTrim() (gas: 11354)
Suite result: ok. 15 passed; 0 failed; 0 skipped; finished in 626.17µs (1.30ms CPU time)
```