### PR TITLE
Base 64 tests fix

### DIFF
--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -110,7 +110,7 @@ library Base64 {
         uint256 len = bytes(data).length; // Get the length of the input encoded data
         if (len == 0) return ""; // If the input is empty, return an empty bytes array
         if (len > MAX_ENCODED_LENGTH) revert Base64InputTooLong();
-        if (len % 4 == 0) revert Base64InvalidInputLength(); // Ensure input is properly padded
+        if (len % 4 != 0) revert Base64InvalidInputLength(); // Ensure input is properly padded
         bytes memory bytesTable = bytes(table);
         uint256 bytesTableLength = bytesTable.length;
         // Initialize the decoding lookup table (map characters to their indices)

--- a/test/utils/TestBase64.t.sol
+++ b/test/utils/TestBase64.t.sol
@@ -17,7 +17,7 @@ contract Base64Test is Test {
     function testEncodeURL() public pure {
         bytes memory data = bytes("http://lazy.fun:8545");
         string memory encodedURL = Base64.encodeURL(data);
-        string memory expected = "aHR0cDovL3BlcGUuY29tOjg1NDU=";
+        string memory expected = "aHR0cDovL2xhenkuZnVuOjg1NDU=";
         assertEq(encodedURL, expected, "Base64URL encode failed");
     }
 
@@ -70,10 +70,10 @@ contract Base64Test is Test {
             tooLongInput[i] = 0x41; // ASCII 'A'
         }
 
-        vm.expectRevert("Base64: input too long");
+        vm.expectRevert(Base64.Base64InputTooLong.selector);
         Base64.encode(tooLongInput);
 
-        vm.expectRevert("Base64: input too long");
+        vm.expectRevert(Base64.Base64InputTooLong.selector);
         Base64.encodeURL(tooLongInput);
 
         // Test with exactly max length (should pass)
@@ -91,10 +91,10 @@ contract Base64Test is Test {
         // Create input with length not multiple of 4
         string memory invalidLength = "SGVsbG8=W"; // 9 characters
 
-        vm.expectRevert("Base64: invalid input length");
+        vm.expectRevert(Base64.Base64InvalidInputLength.selector);
         Base64.decode(invalidLength);
 
-        vm.expectRevert("Base64: invalid input length");
+        vm.expectRevert(Base64.Base64InvalidInputLength.selector);
         Base64.decodeURL(invalidLength);
     }
 }


### PR DESCRIPTION
# Pull Request

## Description
Fixes logics related to Base64

All tests pass
```solidity
Ran 10 tests for test/utils/TestBase64.t.sol:Base64Test
[PASS] testDecode() (gas: 23748)
[PASS] testDecodePath() (gas: 6780)
[PASS] testEmptyEncodeDecode() (gas: 4894)
[PASS] testEmptyEncodeDecodeURL() (gas: 4732)
[PASS] testEncode() (gas: 6134)
[PASS] testEncodeDecode() (gas: 44099)
[PASS] testEncodeDecodeURL() (gas: 33775)
[PASS] testEncodeMaxLength() (gas: 130099800)
[PASS] testEncodeURL() (gas: 6694)
[PASS] testInvalidDecodeLength() (gas: 3754)
Suite result: ok. 10 passed; 0 failed; 0 skipped; finished in 253.67ms (253.89ms CPU time)
```